### PR TITLE
Replaces text with real cards

### DIFF
--- a/src/main/java/assets/css/AcesUp.css
+++ b/src/main/java/assets/css/AcesUp.css
@@ -5,7 +5,6 @@ width:500px;
 td{
 width:100px;
 height:20px;
-text-align:center;
 }
 
 .title{
@@ -15,4 +14,36 @@ font-weight: bold;
 .cardLocation{
 width: 100px;
 background-color:#F0F0F0;
+}
+
+.playingCard{
+    width:100px;
+    height:150px;
+    border:2px solid black;
+}
+.smallPlayingCard{
+    width:100px;
+    height:25px;
+    border-top:2px solid black;
+    border-right:2px solid black;
+    border-left:2px solid black;
+}
+.cardValue{
+    display:inline-block;
+    padding: 5px 2px 0px 10px;
+    font-size:20px;
+
+}
+.cardSuit{
+    display:inline-block;
+    font-size:20px;
+
+}
+.cardSuitBig{
+    text-align:center;
+    margin:auto;
+
+    padding: 0px;
+    font-size:75px;
+    display:block;
 }

--- a/src/main/java/views/AcesUp/AcesUp.flt.html
+++ b/src/main/java/views/AcesUp/AcesUp.flt.html
@@ -99,24 +99,51 @@ console.log(game);
 
 $( '.columnOfCards .cardLocation' ).html("");
 
-    $.each(game.cols[0], function( key, val ) {
-        $( '#c0 .l'+key ).html(val.value + val.suit);
-    });
+    //loop through each column
+    for(var i = 0; i < 4; i++){
+        var htmlCard;
 
- $.each(game.cols[1], function( key, val ) {
-        $( '#c1 .l'+key ).html(val.value + val.suit);
-    });
+        //update the html of each card in the column
+        $.each(game.cols[i], function(key, val){
 
- $.each(game.cols[2], function( key, val ) {
-        $( '#c2 .l'+key ).html(val.value + val.suit);
-    });
+            //change the html to a fullsize card if it is the last card
+            if(game.cols[i].length-1 == key){
+                htmlCard = "<div class=\"playingCard\"><span class=\"cardValue\">"+valueToCard(val.value)+"</span><span class=\"cardSuit\">&"+suitToUnicode(val.suit)+";</span><span class=\"cardSuitBig\">&"+suitToUnicode(val.suit)+";</span></div>";
+            }
 
- $.each(game.cols[3], function( key, val ) {
-        $( '#c3 .l'+key ).html(val.value + val.suit);
-    });
+            //change the html to the header of a card
+            else{
+                htmlCard = "<div class=\"smallPlayingCard\"><span class=\"cardValue\">"+valueToCard(val.value)+"</span><span class=\"cardSuit\">&"+suitToUnicode(val.suit)+";</div>";
+            }
 
+            //write the html into the table element
+            $( '#c'+i+' .l'+key ).html(htmlCard);
+        });
+    }
+}
 
+//convert a string suit to it's unicode version. For example: "Hearts" becomes "hearts"
+function suitToUnicode(suit){
+    if(suit == "Diamonds")
+        return "diams";
+    else
+        return suit.toLowerCase();
+}
 
+//convert a string card value to a face card letter if applicable
+function valueToCard(value){
+    switch(value){
+        case 11:
+            return "J";
+        case 12:
+            return "Q";
+        case 13:
+            return "K";
+        case 14:
+            return "A";
+        default:
+            return value;
+    }
 }
 
 // Calls ApplicationController.gameGet()


### PR DESCRIPTION
fixes #18 

There are two versions of a card. One is the fullsize card, and the other is the top header of the card. Integrated with the JavaScript so that cards in columns should be displaying real cards now, also implemented a check to always change the html of the last card of a column to the fullsize version.

There are several odd behaviors involving resizing of the columns table elements when removing cards as well as the table itself growing when adding cards.